### PR TITLE
Fix association count logic

### DIFF
--- a/rs_take_home/association_counter.py
+++ b/rs_take_home/association_counter.py
@@ -56,7 +56,6 @@ class AssociationCounter(BaseModelArbitrary):
             self.gene_disease_associations
             .count_associations(
                 list_disease_ids=child_parent_diseases,
-                gene_id=gene_id,
             )
         )
         query = f'({gene_id}, {disease_id})'

--- a/rs_take_home/data_models.py
+++ b/rs_take_home/data_models.py
@@ -29,14 +29,13 @@ class GeneDiseaseAssociations(BaseModelArbitrary):
         self,
         *,
         list_disease_ids: List[str],
-        gene_id: str,
     ) -> int:
         return (
             self.df
             .filter(
-                (fx.col(_disease_id_col).isin(list_disease_ids))  # noqa: E501, WPS465
-                & (fx.col(_gene_id_col) == gene_id),
+                fx.col(_disease_id_col).isin(list_disease_ids),
             )
+            .select(_gene_id_col)
             .distinct()
             .count()
         )

--- a/rs_take_home/run.py
+++ b/rs_take_home/run.py
@@ -19,8 +19,10 @@ with open('config/filepaths.json') as json_file:
 
 
 _default_gene_disease_queries = [
+    ('ENSG00000101342', 'MONDO:0019557'),
+    ('ENSG00000101347', 'MONDO:0015574'),
     ('ENSG00000213689', 'MONDO:0019557'),
-    ('ENSG00000184584', 'MONDO:0018827'),
+    ('ENSG00000213689', 'MONDO:0018827'),
 ]
 
 

--- a/rs_take_home/run.py
+++ b/rs_take_home/run.py
@@ -4,6 +4,7 @@ from typing import List
 from pyspark.sql import SparkSession
 
 from rs_take_home.association_counter import AssociationCounter
+from rs_take_home.data_models import DiseaseHierarchy, GeneDiseaseAssociations
 
 spark = (
     SparkSession
@@ -25,11 +26,31 @@ _default_gene_disease_queries = [
     ('ENSG00000213689', 'MONDO:0018827'),
 ]
 
+_default_gene_disease_associations = (
+    GeneDiseaseAssociations
+    .from_filepath(_filepaths_config['gene_disease_associations'], spark)
+)
+
+
+_default_disease_hierarchy = (
+    DiseaseHierarchy
+    .from_filepath(_filepaths_config['disease_hierarchy'], spark)
+)
+
 
 def get_association_counts(
+    gene_disease_associations: GeneDiseaseAssociations = None,
+    disease_hierarchy: DiseaseHierarchy = None,
     queries: List[tuple] = _default_gene_disease_queries,
-    config: dict = _filepaths_config,
     spark: SparkSession = spark,
 ):
-    association_counter = AssociationCounter.from_config(config, spark)
+    if not gene_disease_associations:
+        gene_disease_associations = _default_gene_disease_associations
+    if not disease_hierarchy:
+        disease_hierarchy = _default_disease_hierarchy
+    association_counter = AssociationCounter(
+        disease_hierarchy=disease_hierarchy,
+        gene_disease_associations=gene_disease_associations,
+        spark=spark,
+    )
     return association_counter.count_all_queries(queries)

--- a/rs_take_home/run.py
+++ b/rs_take_home/run.py
@@ -1,10 +1,11 @@
 import json
 from typing import List
 
-from pyspark.sql import SparkSession
+from pyspark.sql import DataFrame, SparkSession
 
 from rs_take_home.association_counter import AssociationCounter
 from rs_take_home.data_models import DiseaseHierarchy, GeneDiseaseAssociations
+from rs_take_home.utils import spark_read_csv
 
 spark = (
     SparkSession
@@ -19,35 +20,33 @@ with open('config/filepaths.json') as json_file:
     _filepaths_config = json.load(json_file)
 
 
-_default_gene_disease_queries = [
+_gene_disease_queries = [
     ('ENSG00000101342', 'MONDO:0019557'),
     ('ENSG00000101347', 'MONDO:0015574'),
     ('ENSG00000213689', 'MONDO:0019557'),
     ('ENSG00000213689', 'MONDO:0018827'),
 ]
 
-_default_gene_disease_associations = (
-    GeneDiseaseAssociations
-    .from_filepath(_filepaths_config['gene_disease_associations'], spark)
+_gene_disease_associations_df = (
+    spark_read_csv(_filepaths_config['gene_disease_associations'], spark)
 )
 
 
-_default_disease_hierarchy = (
-    DiseaseHierarchy
-    .from_filepath(_filepaths_config['disease_hierarchy'], spark)
+_disease_hierarchy_df = (
+    spark_read_csv(_filepaths_config['disease_hierarchy'], spark)
 )
 
 
 def get_association_counts(
-    gene_disease_associations: GeneDiseaseAssociations = None,
-    disease_hierarchy: DiseaseHierarchy = None,
-    queries: List[tuple] = _default_gene_disease_queries,
+    gene_disease_associations_df: DataFrame = _gene_disease_associations_df,
+    disease_hierarchy_df: DataFrame = _disease_hierarchy_df,
+    queries: List[tuple] = _gene_disease_queries,
     spark: SparkSession = spark,
-):
-    if not gene_disease_associations:
-        gene_disease_associations = _default_gene_disease_associations
-    if not disease_hierarchy:
-        disease_hierarchy = _default_disease_hierarchy
+) -> DataFrame:
+    disease_hierarchy = DiseaseHierarchy(df=disease_hierarchy_df)
+    gene_disease_associations = GeneDiseaseAssociations(
+        df=gene_disease_associations_df,
+    )
     association_counter = AssociationCounter(
         disease_hierarchy=disease_hierarchy,
         gene_disease_associations=gene_disease_associations,

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ ignore = D1 WPS348 W503 WPS305 WPS442
 
 per-file-ignores =
 # S101 Use of assert detected.
-# WPS114 Found underscored number name pattern: efo_0005809_diseases
+# WPS114 Found underscored number name pattern
 # WPS202 Found too many module members
 # WPS442 Found outer scope names shadowing
     tests/*: S101 WPS114 WPS202 WPS442

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,12 +8,12 @@ from rs_take_home.data_models import DiseaseHierarchy, GeneDiseaseAssociations
 
 
 @pytest.fixture
-def efo_0005809_diseases():
+def mondo_0019557_diseases():
     return [
-        'EFO:0005809',
-        'EFO:0000540',
-        'MONDO:0004670',
-        'EFO:1002003',
+        'MONDO:0019557',
+        'MONDO:0015574',
+        'MONDO:0018827',
+        'MONDO:0019293',
         'MONDO:0000603',
     ]
 
@@ -21,16 +21,20 @@ def efo_0005809_diseases():
 @pytest.fixture
 def gene_disease_queries():
     return [
+        ('ENSG00000101342', 'MONDO:0019557'),
+        ('ENSG00000101347', 'MONDO:0015574'),
         ('ENSG00000213689', 'MONDO:0019557'),
-        ('ENSG00000184584', 'MONDO:0018827'),
+        ('ENSG00000213689', 'MONDO:0018827'),
     ]
 
 
 @pytest.fixture
 def query_counts_df(spark_session):
     return spark_session.createDataFrame([
-        Row(Query='(ENSG00000213689, MONDO:0019557)', Result=2),
-        Row(Query='(ENSG00000184584, MONDO:0018827)', Result=1),
+        Row(Query='(ENSG00000101342, MONDO:0019557)', Result=4),
+        Row(Query='(ENSG00000101347, MONDO:0015574)', Result=3),
+        Row(Query='(ENSG00000213689, MONDO:0019557)', Result=4),
+        Row(Query='(ENSG00000213689, MONDO:0018827)', Result=3),
     ])
 
 

--- a/tests/test_data_models.py
+++ b/tests/test_data_models.py
@@ -1,13 +1,13 @@
 def test_get_child_and_parent_diseases(
     disease_hierarchy,
-    efo_0005809_diseases,
+    mondo_0019557_diseases,
 ):
-    children_parent_diseases = (
+    child_parent_diseases = (
         disease_hierarchy
-        .get_child_and_parent_diseases('EFO:0005809')
+        .get_child_and_parent_diseases('MONDO:0019557')
     )
     is_child_parent_disease = [
-        _ in efo_0005809_diseases for _ in children_parent_diseases
+        _ in mondo_0019557_diseases for _ in child_parent_diseases
     ]
     assert all(is_child_parent_disease)
 
@@ -17,15 +17,14 @@ def test_count_associations(
     disease_hierarchy,
     gene_disease_associations,
 ):
-    children_parent_diseases = (
+    child_parent_diseases = (
         disease_hierarchy
         .get_child_and_parent_diseases(gene_disease_queries[0][1])
     )
     disease_count = (
         gene_disease_associations
         .count_associations(
-            list_disease_ids=children_parent_diseases,
-            gene_id=gene_disease_queries[0][0],
+            list_disease_ids=child_parent_diseases,
         )
     )
-    assert disease_count == 2
+    assert disease_count == 4


### PR DESCRIPTION
counts all unique genes for a given query, instead of just those with the specified gene id.